### PR TITLE
ci: Add GitHub Actions for automatic pull request labeling based on file paths and size.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+frontend:
+  - changed-files:
+    - any-glob-to-any-file: 'frontend/**'
+
+backend:
+  - changed-files:
+    - any-glob-to-any-file: 'backend/**'
+
+ci/cd:
+  - changed-files:
+    - any-glob-to-any-file: '.github/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,29 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+    - name: Label PR size
+      uses: codelytv/pr-size-labeler@v1
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        xs_label: 'size/xs'
+        xs_max_lines: '10'
+        s_label: 'size/s'
+        s_max_lines: '100'
+        m_label: 'size/m'
+        m_max_lines: '500'
+        l_label: 'size/l'
+        l_max_lines: '1000'
+        xl_label: 'size/xl'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic pull request labeling based on modified file paths and changeset size.
  * Pull requests will now be automatically labeled with size categories (xs, s, m, l, xl) and area labels (frontend, backend, ci/cd) for better organization and triage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->