### PR TITLE
Disable analyze button and improve loading feedback

### DIFF
--- a/frontend/src/components/ImagePreview.tsx
+++ b/frontend/src/components/ImagePreview.tsx
@@ -160,10 +160,17 @@ export const ImagePreview: React.FC<ImagePreviewProps> = ({
           </button>
           <button
             onClick={onUpload}
-            className='flex-1 bg-brand-primary text-white py-4 rounded-2xl font-bold text-lg shadow-lg shadow-brand-primary/20 hover:bg-brand-primary/90 hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center justify-center space-x-2'
+            disabled={loading}
+            aria-busy={loading}
+            className={`flex-1 py-4 rounded-2xl font-bold text-lg shadow-lg transition-all flex items-center justify-center space-x-2
+    ${
+      loading
+        ? 'bg-gray-400 cursor-not-allowed'
+        : 'bg-brand-primary text-white hover:bg-brand-primary/90 hover:scale-[1.02] active:scale-[0.98]'
+    }`}
           >
             <Sparkles className='w-5 h-5' />
-            <span>Analyze</span>
+            <span>{loading ? 'Analyzing…' : 'Analyze'}</span>
           </button>
         </div>
       )}


### PR DESCRIPTION
## What does this PR do?
- Improves user experience during image analysis by providing clear loading feedback.
- Explicitly disables the **Analyze** button while processing to prevent multiple submissions.

## Why is this needed?
Previously, users could attempt multiple actions while image analysis was still in progress, which could cause confusion.  
This change aligns with the issue requirement to provide better clarity and responsiveness.

## Files changed
- `frontend/src/components/ImagePreview.tsx`

## Related Issue
- Fixes: #46
